### PR TITLE
[ADD] folder name validation before App.loadSlideshow()

### DIFF
--- a/app/config.html
+++ b/app/config.html
@@ -1,4 +1,4 @@
-<div class="">
+<div>
   <div class="ui form tall piled segment" style="width: 320px">
     <div class="ui basic segment">
       <h3 class="ui blue header">
@@ -45,6 +45,14 @@
       <div id="load_slideshow_btn" class="ui large primary right labeled icon button">
         <i class="send icon"></i>
         Load slideshow
+      </div>
+    </div>
+    <!-- error message box. hidden by default -->
+    <div data-role="loadingErrorBox" class="ui small floating compact red icon message transition hidden">
+      <i class="red warning icon"></i>
+      <div class="content">
+        <div class="header">Slideshow not found</div>
+        <p>Please check the folder name and retry.</p>
       </div>
     </div>
   </div> <!-- close segments -->

--- a/app/ui.html
+++ b/app/ui.html
@@ -51,7 +51,7 @@
       <h5 class="ui title tiny inverted header">
         <i class="smile icon"></i>
         <div class="content">
-        <i class="dropdown icon"></i>
+          <i class="dropdown icon"></i>
           About
         </div>
       </h5>

--- a/js/app.js
+++ b/js/app.js
@@ -8,7 +8,7 @@ var App = {
     author: 'Daniele Calcinai',
     email: 'dinghino@gmail.com',
     gitHub: 'https://github.com/dinghino',
-    version: '0.9.1RC'
+    version: '0.9.3b'
   },
   // current state of the app
   state : {
@@ -38,6 +38,29 @@ var App = {
     App.semanticModules()
     // initialize the buttons and their events
     Interface.init()
+  },
+
+  /**
+   * validate the selected folder before calling App.loadSlideshow()
+   * avoiding unwanted initialization
+   * @param  {string} folderName folder to validate
+   * @param  {func}   success    called if folderName is found
+   * @param  {func}   failure    called if foldername is NOT found
+   */
+  validateSlideshowFolder: function (folderName, success, failure) {
+    // define the path to the test file
+    var test = folderName + '/0.html'
+
+    $.get(test)
+    .success(function () {
+        console.info('success in accessing', folderName + '/')
+        if (success) success();
+      })
+    .fail(function () {
+        console.warn('failure in accessing', folderName + '/');
+        if (failure) failure();
+      })
+
   },
 
   events: function () {
@@ -175,7 +198,7 @@ var App = {
     about.authorGitHub.attr('href', info.gitHub)
   },
 
-  /** Activate semantic-ui modules */
+  /** Activate slideshow UI semantic-ui modules */
   semanticModules: function () {
     $helpIcon.popup({
       inline: true,

--- a/js/main.js
+++ b/js/main.js
@@ -20,7 +20,20 @@
             showCounter: counter
           }
 
-          App.loadSlideshow(config);
+          function validateSuccess () { App.loadSlideshow(config) };
+          function validateFailure () {
+            var message = $('[data-role="loadingErrorBox"]'),
+                icon = $(message).children('.icon');
+
+            $(message).transition({
+              animation: 'fade up',
+              onComplete: function () {
+                $(icon).transition('tada')
+              }
+            })
+          };
+
+          App.validateSlideshowFolder(folder, validateSuccess, validateFailure);
         });
       }
 


### PR DESCRIPTION
App now tries to validate the folder and shows an error if folder is not found.

test is done by trying to $.get() 0.html inside the given folder.
If get returns a success, the success callback is called (App.loadSlideshow(config).
If get returns a failure, the failure callback is called, showing the message to the user